### PR TITLE
added saas-boilerplate to the list of django templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ If this one is not to your taste, then there are others to consider:
   * [cookiecutter-django](https://github.com/cookiecutter/cookiecutter-django)
   * [django-superapp](https://github.com/django-superapp/django-superapp)
   * [SaaS Pegasus](https://www.saaspegasus.com/)
+  * [SaaS Boilerplate](https://github.com/apptension/saas-boilerplate)
 
 *NOTE: These are not endorsements of these projects. Just examples of other
 ways to get started with Django.*


### PR DESCRIPTION
With r.e.f to Issue #71 , added https://github.com/apptension/saas-boilerplate to our list of django templates.
