### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,5 +1,7 @@
 name: Ruff
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   ruff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/simplecto/django-reference-implementation/security/code-scanning/4](https://github.com/simplecto/django-reference-implementation/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Since the workflow uses `actions/checkout@v4` and `astral-sh/ruff-action@v3`, it likely only needs read access to the repository contents. Therefore, we will set `contents: read` in the `permissions` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
