### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/simplecto/django-reference-implementation/security/code-scanning/5](https://github.com/simplecto/django-reference-implementation/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow. Since the workflow does not perform any repository write operations, we will set `contents: read` to limit the permissions to read-only access to the repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
